### PR TITLE
Implement changes to highlight multiple matches in a single line in HyperSearch

### DIFF
--- a/org/gjt/sp/jedit/search/HyperSearchResults.java
+++ b/org/gjt/sp/jedit/search/HyperSearchResults.java
@@ -593,9 +593,8 @@ public class HyperSearchResults extends JPanel implements DefaultFocusComponent
 				try {
 					m = matcher.nextMatch(s.substring(i), true, true, true, false);
 				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-				} finally {
 					m = null;
+					Thread.currentThread().interrupt();
 				}
 			}
 			return HtmlUtilities.highlightString(s, styleTag, matches);


### PR DESCRIPTION
Change Request #je3 - Fix the HyperSearch feature, so that it's list of results highlights all occurrences of a search string.

Issue identification - When using HyperSearch feature only the first occurrence of the word was highlighted in the result window.

Resolution - In the HyperSearchResults.java:convertValueToText method m was set to null in the finally block. Removed that assignment to the catch block, as finally block is always executed regardless of occurrence of an exception. But it will be set to null when InterruptedException occurs.

Expected Behavior - Every occurrence of the search string will be highlighted in a line as this fix will allow the while(m != null) loop to progress after the first match.