### PR TITLE
implement caret word offset in status bar

### DIFF
--- a/org/gjt/sp/jedit/gui/StatusBar.java
+++ b/org/gjt/sp/jedit/gui/StatusBar.java
@@ -354,7 +354,8 @@ public class StatusBar extends JPanel
 
 			int caretPosition = textArea.getCaretPosition();
 			int currLine = textArea.getCaretLine();
-
+			int wordOffset [] = doWordCount(buffer.getText(), caretPosition);
+			//Log.log(Log.DEBUG, StatusBar.class, "word offset = " + wordOffset[0] + " file words = " + wordOffset[1]);
 			// there must be a better way of fixing this...
 			// the problem is that this method can sometimes
 			// be called as a result of a text area scroll
@@ -418,11 +419,56 @@ public class StatusBar extends JPanel
 				buf.append(bufferLength);
 				buf.append(')');
 			}
+			if (jEdit.getBooleanProperty("view.status.show-caret-word-offset", true))
+			{
+				buf.append('(');
+				buf.append(wordOffset[0]);
+				buf.append('/');
+				buf.append(wordOffset[1]);
+				buf.append(')');
+			}
 
 			caretStatus.setText(buf.toString());
 			buf.setLength(0);
 		}
 	} //}}}
+
+	public int[] doWordCount(String text, int currIndex)
+	{
+		int wordValues[] = new int[2];
+		char[] chars = text.toCharArray();
+		int characters = chars.length;
+		int words = 0;
+		int lines = 1;
+		int characterIndex = 0;
+		boolean word = true;
+		for (char aChar : chars)
+		{
+			switch (aChar)
+			{
+				case '\r':
+				case '\n':
+					lines++;
+				case ' ':
+				case '\t':
+					word = true;
+					break;
+				default:
+					if (word)
+					{
+						words++;
+						word = false;
+					}
+					break;
+			}
+			characterIndex ++;
+			if(characterIndex == currIndex){
+				wordValues[0] = words;
+			}
+		}
+		wordValues[1] = words;
+		return wordValues;
+	}
 
 	//{{{ updateBufferStatus() method
 	public void updateBufferStatus()

--- a/org/gjt/sp/jedit/options/StatusBarOptionPane.java
+++ b/org/gjt/sp/jedit/options/StatusBarOptionPane.java
@@ -107,12 +107,13 @@ public class StatusBarOptionPane extends AbstractOptionPane
 		optionsPanel.addComponent(new JLabel(jEdit.getProperty("options.status.caret.title", "Caret position display options:")));
 
 		/*
-		Caret position format: lineno,dot-virtual (caretpos/bufferlength)
+		Caret position format: lineno,dot-virtual (caretpos/bufferlength)(caret-word-offset/word-count)
 		view.status.show-caret-linenumber -- true shows line number for caret (lineno)
 		view.status.show-caret-dot -- true shows offset in line for caret (dot)
 		view.status.show-caret-virtual -- true shows virtual offset in line for caret (virtual)
 		view.status.show-caret-offset -- true shows caret offset from start of buffer (caretpos)
 		view.status.show-caret-bufferlength -- true shows length of buffer (bufferlength)
+		view.status.show-caret-word-offset -- true shows offset of words till caret position and total words in buffer (caret-word-offset/word-count)
 		*/
 		showCaretLineNumber = new JCheckBox(jEdit.getProperty("options.status.caret.linenumber", "Show caret line number"),
 			jEdit.getBooleanProperty("view.status.show-caret-linenumber", true));
@@ -129,11 +130,15 @@ public class StatusBarOptionPane extends AbstractOptionPane
 		showCaretBufferLength = new JCheckBox(jEdit.getProperty("options.status.caret.bufferlength", "Show length of file"),
 			jEdit.getBooleanProperty("view.status.show-caret-bufferlength", true));
 		showCaretBufferLength.setName("showCaretBufferLength");
+		showCaretWordOffset = new JCheckBox(jEdit.getProperty("options.status.caret.word-offset", "Show word offset for caret position"),
+				jEdit.getBooleanProperty("view.status.show-caret-word-offset", true));
+		showCaretWordOffset.setName("showCaretWordOffset");
 		optionsPanel.addComponent(showCaretLineNumber);
 		optionsPanel.addComponent(showCaretDot);
 		optionsPanel.addComponent(showCaretVirtual);
 		optionsPanel.addComponent(showCaretOffset);
 		optionsPanel.addComponent(showCaretBufferLength);
+		optionsPanel.addComponent(showCaretWordOffset);
 
 		//}}}
 
@@ -237,7 +242,7 @@ public class StatusBarOptionPane extends AbstractOptionPane
 		jEdit.setBooleanProperty("view.status.show-caret-virtual", showCaretVirtual.isSelected());
 		jEdit.setBooleanProperty("view.status.show-caret-offset", showCaretOffset.isSelected());
 		jEdit.setBooleanProperty("view.status.show-caret-bufferlength", showCaretBufferLength.isSelected());
-
+		jEdit.setBooleanProperty("view.status.show-caret-word-offset", showCaretWordOffset.isSelected());
 	} //}}}
 
 	//{{{ Private members
@@ -262,6 +267,7 @@ public class StatusBarOptionPane extends AbstractOptionPane
 	private JCheckBox showCaretVirtual;
 	private JCheckBox showCaretOffset;
 	private JCheckBox showCaretBufferLength;
+	private JCheckBox showCaretWordOffset;
 	//}}}
 
 	//{{{ updateButtons() method

--- a/org/jedit/localization/jedit_en.props
+++ b/org/jedit/localization/jedit_en.props
@@ -1791,6 +1791,7 @@ options.status.caret.linenumber=Show caret line number
 options.status.caret.dot=Show caret offset from start of line
 options.status.caret.virtual=Show caret virtual offset from start of line
 options.status.caret.offset=Show caret offset from start of file
+options.status.caret.word-offset=Show word offset for caret position
 options.status.caret.bufferlength=Show length of file
 options.status.caret.title=Caret position display options:
 #}}}


### PR DESCRIPTION
Change Request #je3 - The left side of the status bar of jEdit reports: the line number containing the caret, the column position of the caret, the character offset of the caret from the beginning of the file, and the number of characters in the file. The request is to modify the status bar to show: the word offset of the caret from the beginning of the file and the number of words in the file.

Issue identification - New implementation needed for word offset of text buffer in the status bar

Resolution - Add a property (checkbox) for word offset in StatusBarOptionsPane, and add a method to return word offset in StatusBar class

Expected Behavior - The status bar should report word offset next to the character offset.